### PR TITLE
fix conda install of built package in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,8 @@ install:
       conda activate test-environment
       export LIBRARY_PATH="$HOME/miniconda/envs/test-environment/lib"
       conda build --python "$SLYCOT_PYTHON_VERSION" $conda_recipe
-      conda install local::slycot
+      slycot_pkg=$(find $CONDA_PREFIX -name 'slycot*.tar.bz2')
+      conda install --use-local $slycot_pkg
     elif [[ $TEST_PKG == dist ]]; then
       pip install scikit-build pytest-cov matplotlib scipy;
       CMAKE_GENERATOR="Unix Makefiles" python setup.py install;


### PR DESCRIPTION
Fix  conda fails on Travis CI one last time (?) before we move to Github Actions.

See https://github.com/python-control/Slycot/pull/139#issuecomment-752524357. The error there is probably because an old Slycot with the wrong Python interpreter is imported.